### PR TITLE
Corrections for the download headers

### DIFF
--- a/src/Spiritix/Html2Pdf/Output/DownloadOutput.php
+++ b/src/Spiritix/Html2Pdf/Output/DownloadOutput.php
@@ -42,14 +42,14 @@ class DownloadOutput extends AbstractOutput
 
         header('Content-Description: File Transfer');
         header('Cache-Control: public; must-revalidate, max-age=0');
-        header('Pragme: public');
+        header('Pragma: public');
         header('Expires: Sat, 26 Jul 1997 05:00:00 GMT');
         header('Last-Modified: ' . gmdate('D, d m Y H:i:s') . ' GMT');
         header('Content-Type: application/force-download');
-        header('Content-Type: application/octec-stream', false);
+        header('Content-Type: application/octet-stream', false);
         header('Content-Type: application/download', false);
         header('Content-Type: application/pdf', false);
-        header('Content-Disposition: attachment; filename="' . basename($fileName) .'";');
+        header('Content-Disposition: attachment; filename="' . basename($fileName) .'"');
         header('Content-Transfer-Encoding: binary');
         header('Content-Length: ' . strlen($this->getPdfData()));
 


### PR DESCRIPTION
The download was working in browsers, but not in one of our C# clients. I believe the problem was mostly from the trailing semi-colon in the Content-Disposition header on line 52.