### PR TITLE
Add escape quotes to binary path

### DIFF
--- a/src/Spiritix/Html2Pdf/Converter.php
+++ b/src/Spiritix/Html2Pdf/Converter.php
@@ -222,12 +222,12 @@ class Converter
     private function getBinaryPath(): string
     {
         return $this->getNodePath() .
-            ' ' .
+            ' "' .
             dirname(__FILE__) .
             DIRECTORY_SEPARATOR . '..' .
             DIRECTORY_SEPARATOR . '..' .
             DIRECTORY_SEPARATOR . '..' .
             DIRECTORY_SEPARATOR .
-            self::JS_BINARY;
+            self::JS_BINARY . '"';
     }
 }


### PR DESCRIPTION
Fixes issue: https://github.com/spiritix/php-chrome-html2pdf/issues/21