### PR TITLE
Support v5 of composer-npm-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "eloquent/composer-npm-bridge": "^4"
+        "eloquent/composer-npm-bridge": "^4|^5"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
The PR adds support for `v5` of the `eloquent/composer-npm-bridge` package, but does not update the dependency in `composer.lock` in this repo.

This will allow any third-party users of this tool to at least manually update to `eloquent/composer-npm-bridge@v5`, again making it possible to migrate over to start using `composer@v2`.

This should resolve #26.