### PR TITLE
fixed double escape bugs

### DIFF
--- a/src/Spiritix/Html2Pdf/Converter.php
+++ b/src/Spiritix/Html2Pdf/Converter.php
@@ -208,7 +208,7 @@ class Converter
      */
     private function buildCommand(): string
     {
-        $options = ProcessUtil::escapeShellArgument(json_encode($this->getOptions()));
+        $options = ProcessUtil::escapeShellArgument(json_encode($this->getOptions(), JSON_UNESCAPED_SLASHES));
         $command = $this->getBinaryPath() . ' -o ' . $options;
 
         return $command;


### PR DESCRIPTION
In the current version, the following codes output a PDF that has its header wrongly generated.

```php
$converter->setOptions([
    'printBackground' => false,
    'displayHeaderFooter' => true,
    'format' => 'a4',
    'margin' => [
        'top' => '12mm',
        'right' => '12mm',
        'left' => '12mm',
        'bottom' => '12mm',
    ],
    'headerTemplate' => '<div class="header" style="margin: 0; width: 100%; text-align: left; font-size: 12px;">Generated by NOJ - https://github.com/ZsgsDesign/NOJ</div>',
    // 'footerTemplate' => view('pdf.contest.footer')->render(),
]);
$outputBinary = $converter->convert();
```

![image](https://user-images.githubusercontent.com/19504567/131250858-f6624719-b865-4eeb-b440-f6498975711e.png)


After carefully checked the source code, I found the problem:

```php
private function buildCommand(): string
{
    $options = ProcessUtil::escapeShellArgument(json_encode($this->getOptions()));
    $command = $this->getBinaryPath() . ' -o ' . $options;

    return $command;
}
```

In `escapeShellArgument()`, the process would be:
```php
private static function escapeShellArgumentWindows(string $argument): string
{
    // Double up existing backslashes
    $argument = preg_replace('/\\\/', '\\\\\\\\', $argument);

    // Double up double quotes
    $argument = preg_replace('/"/', '""', $argument);

    // Double up percents.
    $argument = preg_replace('/%/', '%%', $argument);

    // Add surrounding quotes.
    $argument = '"' . $argument . '"';

    return $argument;
}
```

Note that drupal uses `\\\` instead of `\\\\`, but it's OK with current PHP, so it's not a bug right now. The problem here is drupal doesn't consider the situation of formatted JSON with slashes so it just adding another slash to the existing slash, making node parsing it to `\` after `popen`.

There are two ways to fix this, either using PHP or node.js. I am proposing adding option  JSON_UNESCAPED_SLASHES to `json_encode` to avoid such bugs. 

Here is the outcome:
![image](https://user-images.githubusercontent.com/19504567/131250890-10516c89-996d-4c90-acea-e268430bc135.png)
