### PR TITLE
Fix renamed page.emulateMedia to page.emulateMediaType

### DIFF
--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -59,7 +59,7 @@ class Converter
         let options = this.getOptions();
 
         if (options.hasOwnProperty('mediaType')) {
-            await page.emulateMedia(options.mediaType);
+            await page.emulateMediaType(options.mediaType);
             delete options.mediaType;
         }
 


### PR DESCRIPTION
https://github.com/puppeteer/puppeteer/issues/395#issuecomment-972802683

Fixes error:

```
Binary error: vendor/spiritix/php-chrome-html2pdf/lib/Converter.js:62
await page.emulateMedia(options.mediaType);
^

TypeError: page.emulateMedia is not a function
at Converter._convert (vendor/spiritix/php-chrome-html2pdf/lib/Converter.js:62:24)
at Converter.run (vendor/spiritix/php-chrome-html2pdf/lib/Converter.js:37:35)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async vendor/spiritix/php-chrome-html2pdf/index.js:23:20

Node.js v18.9.0
``` 